### PR TITLE
feat: gate GA4 behind cookie consent

### DIFF
--- a/src/components/CookieConsent.astro
+++ b/src/components/CookieConsent.astro
@@ -1,0 +1,32 @@
+---
+
+---
+
+<div
+  id="cookie-consent"
+  class="fixed right-0 bottom-0 left-0 z-50 hidden items-center justify-between border-t border-[rgb(var(--border))] bg-[rgb(var(--background))] p-4 text-sm"
+>
+  <span>We use cookies for analytics. Do you accept?</span>
+  <button
+    id="cookie-accept"
+    class="ml-4 rounded bg-[rgb(var(--foreground))] px-4 py-2 text-[rgb(var(--background))]"
+  >
+    Accept
+  </button>
+</div>
+<script is:inline>
+  const banner = document.getElementById("cookie-consent");
+  const acceptBtn = document.getElementById("cookie-accept");
+  const consent = localStorage.getItem("cookie-consent");
+  if (consent === "true") {
+    banner.remove();
+  } else {
+    banner.classList.remove("hidden");
+    banner.classList.add("flex");
+  }
+  acceptBtn?.addEventListener("click", () => {
+    localStorage.setItem("cookie-consent", "true");
+    banner.remove();
+    window.dispatchEvent(new Event("cookie-consent-accepted"));
+  });
+</script>

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -7,6 +7,7 @@ import AboutMe from "../components/AboutMe.astro";
 import ContactForm from "../components/ContactForm.astro";
 import Projects from "../components/Projects.astro";
 import Ga4 from "./ga4.astro";
+import CookieConsent from "../components/CookieConsent.astro";
 import PainPoints from "../components/PainPoints.astro";
 import AboutAutomations from "../components/AboutAutomations.astro";
 import WhoIsItFor from "../components/WhoIsItFor.astro";
@@ -28,6 +29,7 @@ import WhoIsItFor from "../components/WhoIsItFor.astro";
   <body
     class="bg-[rgb(var(--background))] font-sans text-[rgb(var(--foreground))]"
   >
+    <CookieConsent />
     <Hero />
     <div class="w-full border-t border-[rgb(var(--border))]"></div>
 

--- a/src/layouts/ga4.astro
+++ b/src/layouts/ga4.astro
@@ -2,16 +2,28 @@
 const GA_ID = "G-M9XLGBDWY6";
 ---
 
-<!-- Load gtag.js -->
-<script async src={`https://www.googletagmanager.com/gtag/js?id=${GA_ID}`}
-></script>
+<script is:inline>
+  const GA_ID = "G-M9XLGBDWY6";
 
-<!-- Inline config -->
-<script
-  set:html={`
-  window.dataLayer = window.dataLayer || [];
-  function gtag(){dataLayer.push(arguments);}
-  gtag('js', new Date());
-  gtag('config', '${GA_ID}');
-`}
-/>
+  function loadGA() {
+    if (window.gtag) return;
+    const script = document.createElement("script");
+    script.async = true;
+    script.src = `https://www.googletagmanager.com/gtag/js?id=${GA_ID}`;
+    document.head.appendChild(script);
+
+    window.dataLayer = window.dataLayer || [];
+    function gtag() {
+      dataLayer.push(arguments);
+    }
+    window.gtag = gtag;
+    gtag("js", new Date());
+    gtag("config", GA_ID);
+  }
+
+  if (localStorage.getItem("cookie-consent") === "true") {
+    loadGA();
+  } else {
+    window.addEventListener("cookie-consent-accepted", loadGA, { once: true });
+  }
+</script>


### PR DESCRIPTION
## Summary
- load Google Analytics only after cookie consent
- add cookie consent banner

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a56f665ebc8321bfb842de23f5f964