### PR TITLE
Add footer with credit and privacy policy link

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -1,0 +1,9 @@
+---
+const currentYear = new Date().getFullYear();
+---
+<footer class="w-full border-t border-[rgb(var(--border))] py-6 text-center text-sm">
+  <p>
+    © {currentYear} RoeyTech. All rights reserved.
+    <a href="/privacy-policy" class="ml-2 underline">Privacy Policy</a>
+  </p>
+</footer>

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -11,6 +11,7 @@ import CookieConsent from "../components/CookieConsent.astro";
 import PainPoints from "../components/PainPoints.astro";
 import AboutAutomations from "../components/AboutAutomations.astro";
 import WhoIsItFor from "../components/WhoIsItFor.astro";
+import Footer from "../components/Footer.astro";
 ---
 
 <html lang="he" dir="rtl">
@@ -53,5 +54,6 @@ import WhoIsItFor from "../components/WhoIsItFor.astro";
     <Qna />
     <div class="w-full border-t border-[rgb(var(--border))]"></div>
     <ContactForm action="/api/contact" id="contact" />
+    <Footer />
   </body>
 </html>

--- a/src/pages/privacy-policy.astro
+++ b/src/pages/privacy-policy.astro
@@ -1,0 +1,24 @@
+---
+import "../styles/global.css";
+import Ga4 from "../layouts/ga4.astro";
+import Footer from "../components/Footer.astro";
+---
+<html lang="he" dir="rtl">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <Ga4 />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Rubik:wght@400;500;700&display=swap"
+      rel="stylesheet"
+    />
+    <title>Privacy Policy - roeytech.dev</title>
+  </head>
+  <body class="bg-[rgb(var(--background))] font-sans text-[rgb(var(--foreground))]">
+    <main class="mx-auto max-w-3xl p-4">
+      <h1 class="mb-4 text-2xl font-bold">Privacy Policy</h1>
+      <p>This page outlines the privacy practices for roeytech.dev.</p>
+    </main>
+    <Footer />
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- add footer component with developer credit and privacy policy link
- include footer across site layout and privacy policy page
- add basic privacy policy page

## Testing
- `npm test` (fails: Missing script)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a574b30da0832190df58a7f81c7da5