### PR TITLE
Add privacy policy page and link

### DIFF
--- a/src/components/ContactForm.astro
+++ b/src/components/ContactForm.astro
@@ -111,7 +111,7 @@ import ContactIcons from "./ContactIcons.astro";
           <label class="text-base text-[rgb(var(--foreground))]">
             אני מסכים ל
             <a
-              href="#"
+              href="/privacypolicy"
               target="_blank"
               rel="noopener noreferrer"
               class="text-violet-500 underline">מדיניות הפרטיות</a

--- a/src/pages/privacypolicy.astro
+++ b/src/pages/privacypolicy.astro
@@ -1,0 +1,15 @@
+---
+import "../styles/global.css";
+---
+
+<html lang="he" dir="rtl">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>מדיניות פרטיות</title>
+  </head>
+  <body class="bg-[rgb(var(--background))] p-8 text-[rgb(var(--foreground))]">
+    <h1 class="mb-4 text-3xl font-bold">מדיניות פרטיות</h1>
+    <p>זהו טקסט זמני עבור מדיניות הפרטיות. תוכן מלא יתווסף בהמשך.</p>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- link privacy policy to actual page
- add placeholder privacy policy page

## Testing
- `npm test` (fails: Missing script)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a57509fdc48321b88c56e8875bb7f3