### PR TITLE
style: adjust cookie consent modal for mobile

### DIFF
--- a/src/components/CookieConsent.astro
+++ b/src/components/CookieConsent.astro
@@ -4,10 +4,10 @@
 
 <div
   id="cookie-consent"
-  class="fixed inset-0 z-50 hidden items-center justify-center bg-black/50"
+  class="fixed right-0 bottom-0 left-0 z-50 hidden justify-center p-4 md:inset-0 md:items-center md:justify-center md:bg-black/50"
 >
   <div
-    class="max-w-md rounded-lg border border-[rgb(var(--border))] bg-[rgb(var(--foreground))] p-6 text-center text-[rgb(var(--background))] shadow-lg"
+    class="w-full max-w-md rounded-lg border border-[rgb(var(--border))] bg-[rgb(var(--foreground))] p-4 text-center text-[rgb(var(--background))] shadow-lg md:p-6"
   >
     <p class="mb-4">
       כדי להעניק לך חוויה נעימה ומקצועית אנחנו משתמשים בעוגיות. ניתן לעיין ב


### PR DESCRIPTION
## Summary
- position cookie consent modal at bottom on mobile screens
- keep text and desktop layout unchanged

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a595bc5ca0832199987e992b6e0d2f