### PR TITLE
refactor: move inline text to variables

### DIFF
--- a/src/components/ContactIcons.astro
+++ b/src/components/ContactIcons.astro
@@ -14,6 +14,12 @@ const {
   phone = "+972557294597",
   message = "Hello!",
 } = Astro.props;
+const whatsappText = "WhatsApp";
+const emailText = "אימייל";
+const phoneText = "טלפון";
+const whatsappAriaLabel = "WhatsApp";
+const emailAriaLabel = "Email";
+const phoneAriaLabel = "Phone";
 ---
 
 <div class="flex items-center justify-center gap-6 py-6">
@@ -24,11 +30,11 @@ const {
       target="_blank"
       rel="noopener noreferrer"
       class="rounded-full bg-green-500 p-3 text-[rgb(var(--foreground))] transition hover:opacity-90"
-      aria-label="WhatsApp"
+      aria-label={whatsappAriaLabel}
     >
       <MessageCircleMore class="h-6 w-6" />
     </a>
-    <h1 class="text-base text-[rgb(var(--foreground))]">WhatsApp</h1>
+    <h1 class="text-base text-[rgb(var(--foreground))]">{whatsappText}</h1>
   </span>
 
   <!-- Email -->
@@ -36,11 +42,11 @@ const {
     <a
       href={`mailto:${email}`}
       class="rounded-full bg-blue-500 p-3 text-[rgb(var(--foreground))] transition hover:opacity-90"
-      aria-label="Email"
+      aria-label={emailAriaLabel}
     >
       <Mail class="h-6 w-6" />
     </a>
-    <h1 class="text-base text-[rgb(var(--foreground))]">אימייל</h1>
+    <h1 class="text-base text-[rgb(var(--foreground))]">{emailText}</h1>
   </span>
 
   <!-- Phone -->
@@ -48,10 +54,10 @@ const {
     <a
       href={`tel:${phone}`}
       class="rounded-full bg-purple-500 p-3 text-[rgb(var(--foreground))] transition hover:opacity-90"
-      aria-label="Phone"
+      aria-label={phoneAriaLabel}
     >
       <Phone class="h-6 w-6" />
     </a>
-    <h1 class="text-base text-[rgb(var(--foreground))]">טלפון</h1>
-  </span>
+    <h1 class="text-base text-[rgb(var(--foreground))]">{phoneText}</h1>
+</span>
 </div>

--- a/src/components/CookieConsent.astro
+++ b/src/components/CookieConsent.astro
@@ -1,5 +1,9 @@
 ---
-
+const consentPrefix = "כדי להעניק לך חוויה נעימה ומקצועית אנחנו משתמשים בעוגיות. ניתן לעיין ב";
+const confidentialityAgreementText = "הסכם הסודיות";
+const consentQuestion = ". מאשר שימוש בעוגיות?";
+const acceptText = "מאשר";
+const declineText = "לא מעוניין";
 ---
 
 <div
@@ -10,26 +14,26 @@
     class="w-full max-w-md rounded-lg border border-[rgb(var(--border))] bg-[rgb(var(--foreground))] p-4 text-center text-[rgb(var(--background))] shadow-lg md:p-6"
   >
     <p class="mb-4">
-      כדי להעניק לך חוויה נעימה ומקצועית אנחנו משתמשים בעוגיות. ניתן לעיין ב
+      {consentPrefix}
       <a
         href="/privacy-policy"
         target="_blank"
         rel="noopener noreferrer"
-        class="underline">הסכם הסודיות</a
-      >. מאשר שימוש בעוגיות?
+        class="underline">{confidentialityAgreementText}</a
+      >{consentQuestion}
     </p>
     <div class="flex justify-center gap-2">
       <button
         id="cookie-accept"
         class="rounded bg-[rgb(var(--primary))] px-4 py-2 font-semibold text-[rgb(var(--primary-foreground))]"
       >
-        מאשר
+        {acceptText}
       </button>
       <button
         id="cookie-decline"
         class="rounded bg-[rgb(var(--muted))] px-3 py-1 text-sm text-[rgb(var(--muted-foreground))]"
       >
-        לא מעוניין
+        {declineText}
       </button>
     </div>
   </div>

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -1,9 +1,13 @@
 ---
 const currentYear = new Date().getFullYear();
+const copyrightSymbol = "©";
+const companyName = "RoeyTech";
+const rightsReservedText = "All rights reserved.";
+const privacyPolicyText = "Privacy Policy";
 ---
 <footer class="w-full border-t border-[rgb(var(--border))] py-6 text-center text-sm">
   <p>
-    © {currentYear} RoeyTech. All rights reserved.
-    <a href="/privacy-policy" class="ml-2 underline">Privacy Policy</a>
+    {copyrightSymbol} {currentYear} {companyName}. {rightsReservedText}
+    <a href="/privacy-policy" class="ml-2 underline">{privacyPolicyText}</a>
   </p>
 </footer>


### PR DESCRIPTION
## Summary
- refactor footer, contact icons, and cookie consent components to define display text as variables

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68b3ff58fa348321939d15f204cb1584